### PR TITLE
Simplify convert_to_unicode() in tokenization.py

### DIFF
--- a/data/get_bert_embeddings/tokenization.py
+++ b/data/get_bert_embeddings/tokenization.py
@@ -24,24 +24,14 @@ import six
 import tensorflow as tf
 
 
-def convert_to_unicode(text):
+def convert_to_unicode(text, errors="ignore"):
   """Converts `text` to Unicode (if it's not already), assuming utf-8 input."""
-  if six.PY3:
-    if isinstance(text, str):
-      return text
-    elif isinstance(text, bytes):
-      return text.decode("utf-8", "ignore")
-    else:
-      raise ValueError("Unsupported string type: %s" % (type(text)))
-  elif six.PY2:
-    if isinstance(text, str):
-      return text.decode("utf-8", "ignore")
-    elif isinstance(text, unicode):
-      return text
-    else:
-      raise ValueError("Unsupported string type: %s" % (type(text)))
+  if isinstance(text, six.text_type):
+    return text
+  elif isinstance(text, six.binary_type):
+    return text.decode("utf-8", errors)
   else:
-    raise ValueError("Not running on Python2 or Python 3?")
+    raise ValueError("Unsupported string type: %s" % (type(text)))
 
 
 def printable_text(text):


### PR DESCRIPTION
```python
def convert_to_unicode(text, errors="ignore"):
  """Converts `text` to Unicode (if it's not already), assuming utf-8 input."""
  if isinstance(text, six.text_type):
    return text
  elif isinstance(text, six.binary_type):
    return text.decode("utf-8", errors)
  else:
    raise ValueError("Unsupported string type: %s" % (type(text)))
```