### PR TITLE
cuda(async) —> cuda(non_blocking) for Python >= 3.7

### DIFF
--- a/dataloaders/vcr.py
+++ b/dataloaders/vcr.py
@@ -261,8 +261,8 @@ def collate_fn(data, to_gpu=False):
 
     if to_gpu:
         for k in td:
-            td[k] = {k2: v.cuda(async=True) for k2, v in td[k].items()} if isinstance(td[k], dict) else td[k].cuda(
-                async=True)
+            td[k] = {k2: v.cuda(non_blocking=True) for k2, v in td[k].items()} if isinstance(td[k], dict) else td[k].cuda(
+                non_blocking=True)
     # # No nested dicts
     # for k in sorted(td.keys()):
     #     if isinstance(td[k], dict):

--- a/models/train.py
+++ b/models/train.py
@@ -72,8 +72,8 @@ def _to_gpu(td):
     if NUM_GPUS > 1:
         return td
     for k in td:
-        td[k] = {k2: v.cuda(async=True) for k2, v in td[k].items()} if isinstance(td[k], dict) else td[k].cuda(
-            async=True)
+        td[k] = {k2: v.cuda(non_blocking=True) for k2, v in td[k].items()} if isinstance(td[k], dict) else td[k].cuda(
+            non_blocking=True)
     return td
 num_workers = (4 * NUM_GPUS if NUM_CPUS == 32 else 2*NUM_GPUS)-1
 print(f"Using {num_workers} workers out of {NUM_CPUS} possible", flush=True)


### PR DESCRIPTION
__async__ is a reserved word in Python 3.7 and later.  To fix this pytorch/pytorch#4999 changed __cuda(async=True)__ to __cuda(non_blocking=True)__ so this PR tracks with that change which landed in PyTourch 0.4.1.

[flake8](http://flake8.pycqa.org) testing of https://github.com/rowanz/r2c on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./data/get_bert_embeddings/tokenization.py:39:27: F821 undefined name 'unicode'
    elif isinstance(text, unicode):
                          ^
./data/get_bert_embeddings/tokenization.py:62:27: F821 undefined name 'unicode'
    elif isinstance(text, unicode):
                          ^
./dataloaders/vcr.py:264:37: E999 SyntaxError: invalid syntax
            td[k] = {k2: v.cuda(async=True) for k2, v in td[k].items()} if isinstance(td[k], dict) else td[k].cuda(
                                    ^
./models/train.py:75:33: E999 SyntaxError: invalid syntax
        td[k] = {k2: v.cuda(async=True) for k2, v in td[k].items()} if isinstance(td[k], dict) else td[k].cuda(
                                ^
2     E999 SyntaxError: invalid syntax
2     F821 undefined name 'unicode'
4
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
