### PR TITLE
Bert train fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,12 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# bert-embeddings
+data/bert_da*
+
+# Data Annotations
+data/*.jsonl
+
+# Data symbolic link
+data/vcr1images

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ data/*.jsonl
 
 # Data symbolic link
 data/vcr1images
+
+# Submission File
+models/submission.csv

--- a/data/get_bert_embeddings/extract_features.py
+++ b/data/get_bert_embeddings/extract_features.py
@@ -206,7 +206,7 @@ estimator = tf.contrib.tpu.TPUEstimator(
     config=run_config,
     predict_batch_size=FLAGS.batch_size)
 
-input_fn = input_fn_builder(
+input_fn, input_init_hook = input_fn_builder(
     features=features, seq_length=FLAGS.max_seq_length)
 
 output_h5_qa = h5py.File(f'../{FLAGS.name}_answer_{FLAGS.split}.h5', 'w')
@@ -254,7 +254,9 @@ def alignment_gather(alignment, layer):
     return output_embs
 
 
-for result in tqdm(estimator.predict(input_fn, yield_single_examples=True)):
+for result in tqdm(estimator.predict(input_fn, 
+                                     hooks=[input_init_hook],
+                                     yield_single_examples=True)):
     ind = unique_id_to_ind[int(result["unique_id"])]
 
     text, ctx_alignment, choice_alignment = examples[ind]

--- a/models/eval_for_leaderboard.py
+++ b/models/eval_for_leaderboard.py
@@ -39,14 +39,14 @@ parser.add_argument(
 parser.add_argument(
     '-answer_ckpt',
     dest='answer_ckpt',
-    default='saves/flagship_answer/best.th',
+    default='/data/vcr/saves/flagship_answer/best.th',
     help='Answer checkpoint',
     type=str,
 )
 parser.add_argument(
     '-rationale_ckpt',
     dest='rationale_ckpt',
-    default='saves/flagship_rationale/best.th',
+    default='/data/vcr/saves/flagship_rationale/best.th',
     help='Rationale checkpoint',
     type=str,
 )
@@ -71,7 +71,8 @@ def _to_gpu(td):
     if NUM_GPUS > 1:
         return td
     for k in td:
-        td[k] = {k2: v.cuda(async=True) for k2, v in td[k].items()} if isinstance(td[k], dict) else td[k].cuda(
+        if k != 'metadata':
+            td[k] = {k2: v.cuda(async=True) for k2, v in td[k].items()} if isinstance(td[k], dict) else td[k].cuda(
             async=True)
     return td
 


### PR DESCRIPTION
Include tf placeholders rather than constants for calculating bert embeddings. Otherwise, it violates the tensorflow's 2GB protocol.
fixes #15 